### PR TITLE
Fixed bug in CCommand constructor that could append junk to the comma…

### DIFF
--- a/mp/src/tier1/convar.cpp
+++ b/mp/src/tier1/convar.cpp
@@ -359,7 +359,7 @@ CCommand::CCommand( int nArgC, const char **ppArgV )
 		{
 			*pSBuf++ = '\"';
 		}
-		memcpy( pSBuf, ppArgV[i], nLen );
+		memcpy( pSBuf, ppArgV[i], nLen+1 );
 		pSBuf += nLen;
 		if ( bContainsSpace )
 		{


### PR DESCRIPTION
…nd string

* Missed copying the null terminator
* Since m_pArgSBuffer is not initialized this problem can occur when the (command string buffer length) + 1 char in m_pArgSBuffer array happens to be non-zero.